### PR TITLE
fix null params in builtin calls

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -586,7 +586,7 @@ const getExpression = (expr) => {
     case 'builtincall':
       let args = '';
       if (expr.args) {
-        args = expr.args.map(getElem).join(', ');
+        args = expr.args.filter(e => e != null).map(getElem).join(', ');
       }
       return getBracketted(`${expr.builtincall}(${args})`, expr.bracketted);
     case 'unaryexpression':

--- a/test/null_error.rq
+++ b/test/null_error.rq
@@ -1,0 +1,1 @@
+SELECT * WHERE {	BIND(REPLACE(?keepId, "^(.+)$", ?formatter) AS ?keepUrl)}


### PR DESCRIPTION
Hello,

We are using you parser and noticed that [this query](https://github.com/the-qa-company/qEndpoint/issues/401) wasn't working, after some reducing only this part was the issue:

```sparql
SELECT * WHERE {
    BIND(REPLACE(?keepId, "^(.+)$", ?formatter) AS ?keepUrl)
}
```

This is due to the fact that in your grammar, you add null arguments in your AST, but the formatter isn't parsing them.

https://github.com/sparqling/sparql-formatter/blob/d5b8510cc0c370770916b47d57e1af9f58658337/lib/sparql.pegjs#L1816

I fixed it for the builtin calls, but it might be the case somewhere else, I didn't check.

