### PR TITLE
fix variable definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const parser = require('./lib/parser.js');
 const formatter = require('./lib/formatter.js');
 
-spfmt = (sparql, indentDepth = 2) => {
+const spfmt = (sparql, indentDepth = 2) => {
   return formatter.format(parser.parse(sparql), indentDepth);
 };
 


### PR DESCRIPTION
Bundling this library with Vite, the missing `spfmt` variable initialization triggers an error.